### PR TITLE
Added option to change server side port

### DIFF
--- a/common/helpers.py
+++ b/common/helpers.py
@@ -45,6 +45,9 @@ def cli_parser():
     servers.add_argument(
         "--server", default=None, metavar='[http]',
         help="Create a server for the specified protocol.")
+    servers.add_argument(
+        "--port", default=None, metavar='[80]',
+        help="Specify a non-standard port for the specified protocol.")
     servers.add_argument("--list-servers", default=False, action='store_true',
                          help="Lists all supported server protocols.")
 

--- a/protocols/servers/ftp_server.py
+++ b/protocols/servers/ftp_server.py
@@ -19,6 +19,10 @@ class Server:
         self.username = cli_object.username
         self.password = cli_object.password
         self.data_directory = ""
+        if cli_object.port:
+            self.port = int(cli_object.port)
+        else:
+            self.port = 21
 
     def serve(self):
         # current directory
@@ -43,10 +47,10 @@ class Server:
             handler.banner = "Connecting to Egress-Assess's FTP server!"
 
             try:
-                server = FTPServer(('', 21), handler)
+                server = FTPServer(('', self.port), handler)
                 server.serve_forever()
             except socket.error:
-                print "[*][*] Error: Port 80 is currently in use!"
+                print "[*][*] Error: Port %d is currently in use!" % self.port
                 print "[*][*] Error: Please restart when port is free!\n"
                 sys.exit()
         except ValueError:

--- a/protocols/servers/http_server.py
+++ b/protocols/servers/http_server.py
@@ -16,6 +16,10 @@ class Server:
 
     def __init__(self, cli_object):
         self.protocol = "http"
+        if cli_object.port:
+            self.port = int(cli_object.port)
+        else:
+            self.port = 80
 
     def serve(self):
         try:
@@ -32,10 +36,10 @@ class Server:
     def serve_on_port(self):
         try:
             server80 = threaded_http.ThreadingHTTPServer(
-                ("0.0.0.0", 80), base_handler.GetHandler)
+                ("0.0.0.0", self.port), base_handler.GetHandler)
             server80.serve_forever()
         except socket.error:
-            print "[*][*] Error: Port 80 is currently in use!"
+            print "[*][*] Error: Port %s is currently in use!" % self.port
             print "[*][*] Error: Please restart when port is free!\n"
             sys.exit()
         return

--- a/protocols/servers/https_server.py
+++ b/protocols/servers/https_server.py
@@ -18,6 +18,10 @@ class Server:
 
     def __init__(self, cli_object):
         self.protocol = "https"
+        if cli_object.port:
+            self.port = int(cli_object.port)
+        else:
+            self.port = 443
 
     def serve(self):
         try:
@@ -36,12 +40,12 @@ class Server:
             cert_path = helpers.ea_path() +\
                 '/protocols/servers/serverlibs/web/server.pem'
             server = threaded_http.ThreadingHTTPServer(
-                ("0.0.0.0", 443), base_handler.GetHandler)
+                ("0.0.0.0", self.port), base_handler.GetHandler)
             server.socket = ssl.wrap_socket(
                 server.socket, certfile=cert_path, server_side=True)
             server.serve_forever()
         except socket.error:
-            print "[*][*] Error: Port 443 is currently in use!"
+            print "[*][*] Error: Port %d is currently in use!" % self.port
             print "[*][*] Error: Please restart when port is free!\n"
             sys.exit()
         return

--- a/protocols/servers/sftp_server.py
+++ b/protocols/servers/sftp_server.py
@@ -25,7 +25,10 @@ class Server:
         self.username = cli_object.username
         self.password = cli_object.password
         self.sftp_directory = helpers.ea_path() + '/data'
-        self.port = 22
+        if cli_object.port:
+            self.port = int(cli_object.port)
+        else:
+            self.port = 22
         self.rsa_key = """
         -----BEGIN RSA PRIVATE KEY-----
 MIIEoQIBAAKCAQEArJqP/6XFBa88x/DUootMmSzYa3MxcTV9FjNYUomqbQlGzuHa

--- a/protocols/servers/smtp_server.py
+++ b/protocols/servers/smtp_server.py
@@ -18,6 +18,10 @@ class Server:
     def __init__(self, cli_object):
 
         self.protocol = "smtp"
+        if cli_object.port:
+            self.port = int(cli_object.port)
+        else:
+            self.port = 25
 
     def serve(self):
 
@@ -29,9 +33,9 @@ class Server:
         print "[*] Started SMTP server..."
 
         try:
-            smtp_server = smtp_class.CustomSMTPServer(('0.0.0.0', 25), None)
+            smtp_server = smtp_class.CustomSMTPServer(('0.0.0.0', self.port), None)
         except socket.error:
-            print "[*] Error: Port 25 is currently in use!"
+            print "[*] Error: Port %d is currently in use!" % self.port
             print "[*] Error: Please re-start when not in use."
             sys.exit()
 


### PR DESCRIPTION
Added the ability to specify a non-standard port and override the default ports for each respective service.  If **--port** is specified, *http_server, https_server, ftp_server, and smtp_server* will listen on the specified port. If **--port** is not specified, the servers will listen on the standard port for each respective service, just like they previously were.  

This is helpful in situations where you already have a service already running on port 80,443,etc, but you have the ability to NAT the standard port coming in from the outside to a non-standard port on the inside.

```
./Egress-Assess.py --server http --port 8888
./Egress-Assess.py --server https --port 8443
./Egress-Assess.py --server ftp --port 12345 --username test --password test    
./Egress-Assess.py --server smtp --port 12345
```

 