### PR TITLE
Add UK National Insurance Numbers to Datatypes

### DIFF
--- a/EgressAssess.ps1
+++ b/EgressAssess.ps1
@@ -249,6 +249,49 @@ function Invoke-EgressAssess
             
             $script:AllSSN = $list.ToArray()
         }
+
+        function Generate-NI
+        {
+            $script:AllNI = @()
+            #determine the number of NI based on 9 bytes per NI
+            $num = [math]::Round(($Size * 1MB)/9)
+            Write-Verbose "Generating $Size MB of National Insurance Numbers ($num)..."
+            $list = New-Object System.Collections.Generic.List[System.String]
+
+            for ($i = 0; $i -lt $num; $i++)
+            {
+            
+                if ($Fast) 
+                {
+                    $randString = -join ((65..90) | Get-Random -Count 3 | % {[char]$_})
+                    $randNum = Get-Random -minimum 100 -maximum 1000
+                    $randNumString = [string][int64]$randNum
+                    $randNiBase = "$($randString.substring(0,2))$($randNum)"
+                    $randNiEnd = Get-Random -minimum 100 -maximum 500
+
+                    for ($i2 = $randNiEnd; $i2 -lt $($randNiEnd+500); $i2++)
+                    {
+                        $randNI = "$randNiBase$i2$($randString.substring(2))"
+                        $list.Add($randNI)
+                        $i++
+                    }
+                }
+                
+                else
+                {
+                    $randString = -join ((65..90) | Get-Random -Count 3 | % {[char]$_})
+                    $randNum = Get-Random -minimum 100000000000 -maximum 1000000000000
+                    $randNumString = [string][int64]$randNum
+                    $r = "$($randString.substring(0,2))$($randNumString.substring(0,6))$($randString.substring(2))"
+                    $list.Add($r)
+                    $r = "$($randString.substring(0,2))$($randNumString.substring(6,6))$($randString.substring(2))"
+                    $list.Add($r)
+                    $i++
+                }           
+            }
+            
+            $script:AllNI = $list.ToArray()
+        }
         
         function Generate-CreditCards
         {
@@ -471,6 +514,11 @@ function Invoke-EgressAssess
                     Generate-SSN
                     $Data = $AllSSN
                 }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    $Data = $AllNI
+                }
                 elseif ($Datatype -eq "cc")
                 {
                     Generate-CreditCards
@@ -617,6 +665,11 @@ function Invoke-EgressAssess
                 {
                     Generate-SSN
                     $Data = $AllSSN
+                }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    $Data = $AllNI
                 }
                 elseif ($Datatype -eq "cc")
                 {
@@ -907,6 +960,11 @@ function Invoke-EgressAssess
                     Generate-SSN
                     $Data = $AllSSN
                 }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    $Data = $AllNI
+                }
                 elseif ($Datatype -eq "cc")
                 {
                     Generate-CreditCards
@@ -1012,6 +1070,11 @@ function Invoke-EgressAssess
                 {
                     Generate-SSN
                     $Data = $AllSSN
+                }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    $Data = $AllNI
                 }
                 elseif ($Datatype -eq "cc")
                 {
@@ -1153,6 +1216,11 @@ function Invoke-EgressAssess
                     Generate-SSN
                     $Data = $AllSSN
                 }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    $Data = $AllNI
+                }
                 elseif ($Datatype -eq "cc")
                 {
                     Generate-CreditCards
@@ -1260,6 +1328,11 @@ function Invoke-EgressAssess
                     Generate-SSN
                     $FTPData = $AllSSN
                 }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    $FTPData = $AllNI
+                }
                 elseif ($Datatype -eq "cc")
                 {
                     Generate-CreditCards
@@ -1350,6 +1423,11 @@ function Invoke-EgressAssess
                 {
                     Generate-SSN
                     $FTPData = $AllSSN
+                }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    $FTPData = $AllNI
                 }
                 elseif ($Datatype -eq "cc")
                 {
@@ -1473,6 +1551,11 @@ function Invoke-EgressAssess
                     Generate-SSN
                     $SMTPData = $AllSSN
                 }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    $SMTPData = $AllNI
+                }
                 elseif ($Datatype -eq "cc")
                 {
                     Generate-CreditCards
@@ -1530,6 +1613,11 @@ function Invoke-EgressAssess
                 {
                     Generate-SSN
                     [string]$ICMPData = $AllSSN
+                }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    [string]$ICMPData = $AllNI
                 }
                 elseif ($Datatype -eq "cc")
                 {
@@ -1651,6 +1739,11 @@ function Invoke-EgressAssess
                     Generate-SSN
                     [string]$DNSData = $AllSSN
                 }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    [string]$DNSData = $AllNI
+                }
                 elseif ($Datatype -eq "cc")
                 {
                     Generate-CreditCards
@@ -1734,6 +1827,11 @@ function Invoke-EgressAssess
                     Generate-SSN
                     [string]$DNSData = $AllSSN
                 }
+                elseif ($Datatype -eq "ni")
+                {
+                    Generate-NI
+                    [string]$DNSData = $AllNI
+                }
                 elseif ($Datatype -eq "cc")
                 {
                     Generate-CreditCards
@@ -1792,6 +1890,11 @@ function Invoke-EgressAssess
             {
                 Generate-CreditCards
                 [string]$SMBData = $AllCC
+            }
+            elseif ($Datatype -eq "ni")
+            {
+                Generate-NI
+                [string]$SMBData = $AllNI
             }
             elseif ($Datatype -eq "ssn")
             {

--- a/datatypes/ni_numbers.py
+++ b/datatypes/ni_numbers.py
@@ -1,0 +1,40 @@
+'''
+
+This module generates UK National Insurance Numbers.
+
+Format is 2 prefix letters, 6 digits, 1 suffix letter:
+AB123456C
+
+They are sometimes printed with spaces:
+AB 12 34 56 C
+
+This modules doesn't take correct letter prefixing into account,
+it just generates them randomly. But this is probably good
+enough for basic regex-type filters to detect.
+
+'''
+
+from common import helpers
+
+
+class Datatype:
+
+    def __init__(self, cli_object):
+        self.cli = "ni"
+        self.description = "UK National Insurance Numbers"
+        self.filetype = "text"
+        self.datasize = int(cli_object.data_size)
+
+    def create_ni(self):
+        ni_n = helpers.randomNumbers(6)
+        ni_s = (helpers.randomString(3)).upper()
+        ni = ni_s[0:2] + ni_n[0:6] + ni_s[2:3]
+        return ni
+
+    def generate_data(self):
+        print "[*] Generating data..."
+        nis = ''
+        # This is approx 1 meg of ni's (not including ", ")
+        for single_ni in range(0, 100000 * self.datasize):
+            nis += self.create_ni() + ', '
+        return nis


### PR DESCRIPTION
## Python

```
╭─root@kali /opt/Egress-Assess  ‹ni_numbers*› 
╰─➤  python Egress-Assess.py --list-datatypes

[*] Supported data types: 

[+] cc - (Credit Card Numbers)
[+] identity - (Full names, Addresses, and Socials)
[+] ssn - (Social Security Numbers)
[+] ni - (UK National Insurance Numbers)
```
```
╭─root@kali /opt/Egress-Assess  ‹ni_numbers*› 
╰─➤  python Egress-Assess.py --client http --ip 127.0.0.1 --datatype ni

[*] Generating data...
[*] File sent!!!
```
```
╭─root@kali /opt/Egress-Assess/data  ‹ni_numbers*› 
╰─➤  head -c300 07302017_175134web_data.txt
METADATA: From: ('127.0.0.1', 34208) <bound method GetHandler.address_string of <protocols.servers.serverlibs.web.base_handler.GetHandler instance at 0x7f71cc12fe18>>

LP374462M, QS232432C, WD766932B, WN164000R, QS660960X, PZ427681L, PX535138Y, CE540765Z, KP185698G, PL837575R, FM881933Y, IA250084S,
```

## PowerShell

```
PS C:\Users\Rasta> Invoke-EgressAssess -Client http -IP 192.168.56.100 -Datatype ni -Verbose
VERBOSE: [*] Testing server connection
VERBOSE: [*] Server is UP on 192.168.56.100.
VERBOSE: [*] HTTP Server Running on 192.168.56.100 port 80.
VERBOSE: Generating 1 MB of National Insurance Numbers (116508)...
VERBOSE: Uploading  data...

VERBOSE: [*] Transfer complete!
VERBOSE: [*] 0 loops remaining..
VERBOSE: [*] Exiting..
```
```
╭─root@kali /opt/Egress-Assess/data  ‹ni_numbers*› 
╰─➤  head -c300 07302017_175615web_data.txt 
METADATA: From: ('192.168.56.1', 58159) <bound method GetHandler.address_string of <protocols.servers.serverlibs.web.base_handler.GetHandler instance at 0x7f71cc12fe18>>

ND715144Y ND589436Y YI983525G YI560395G TM756596G TM588029G PJ618196K PJ548718K KL447114N KL904777N ML479394S ML434477S GC155252D
```

```
PS C:\Users\Rasta> Invoke-EgressAssess -Client http -IP 192.168.56.100 -Datatype ni -Verbose -Fast
VERBOSE: [*] Testing server connection
VERBOSE: [*] Server is UP on 192.168.56.100.
VERBOSE: [*] HTTP Server Running on 192.168.56.100 port 80.
VERBOSE: Generating 1 MB of National Insurance Numbers (116508)...
VERBOSE: Uploading  data...

VERBOSE: [*] Transfer complete!
VERBOSE: [*] 0 loops remaining..
VERBOSE: [*] Exiting..
```
```
╭─root@kali /opt/Egress-Assess/data  ‹ni_numbers*› 
╰─➤  head -c300 07302017_175714web_data.txt 
METADATA: From: ('192.168.56.1', 58161) <bound method GetHandler.address_string of <protocols.servers.serverlibs.web.base_handler.GetHandler instance at 0x7f71cc12fe18>>

ZG694410Y ZG694411Y ZG694412Y ZG694413Y ZG694414Y ZG694415Y ZG694416Y ZG694417Y ZG694418Y ZG694419Y ZG694420Y ZG694421Y ZG694422Y
```
